### PR TITLE
Alternative TAP command support

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,6 +3,8 @@ var faucet = require('../');
 var minimist = require('minimist');
 var defined = require('defined');
 var tapeCmd = require.resolve('tape/bin/tape');
+if (process.env.FAUCET_TAP_CMD)
+    tapeCmd = process.env.FAUCET_TAP_CMD;
 
 var spawn = require('child_process').spawn;
 var fs = require('fs');

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,8 +7,15 @@ var tapeCmd = require.resolve('tape/bin/tape');
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
+/**/ console.log("testing...");
+var faucetArgs = process.argv.slice(2);
+var opts = [];
+faucetArgs.forEach(function(arg) {
+    if (arg[0] === '-')
+        opts.push(arg);
+});
+var argv = minimist(faucetArgs);
 
-var argv = minimist(process.argv.slice(2));
 var tap = faucet({
     width: defined(argv.w, argv.width, process.stdout.isTTY
         ? process.stdout.columns - 5
@@ -56,7 +63,8 @@ if (files.length === 0) {
     return process.exit(1);
 }
 
-var tape = spawn(tapeCmd, files);
+var tapeArgs = opts.concat(files);
+var tape = spawn(tapeCmd, tapeArgs);
 tape.stderr.pipe(process.stderr);
 tape.stdout.pipe(tap).pipe(process.stdout);
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var tapeCmd = require.resolve('tape/bin/tape');
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
-/**/ console.log("testing...");
+
 var faucetArgs = process.argv.slice(2);
 var opts = [];
 faucetArgs.forEach(function(arg) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (opts) {
         if (comment === 'fail 0') return; // a mocha thing
         
         if (test && test.ok && test.assertions.length === 0
-        && /^(tests|pass)\s+\d+$/.test(test.name)) {
+        && /^(assertions|tests|pass)\s+\d+$/.test(test.name)) {
             out.push('\r' + trim(test.name));
         }
         else if (test && test.ok) {

--- a/package.json
+++ b/package.json
@@ -7,13 +7,12 @@
     "faucet": "bin/cmd.js"
   },
   "dependencies": {
-    "through2": "~0.2.3",
-    "tap-parser": "~0.4.0",
+    "defined": "0.0.0",
     "duplexer": "~0.1.1",
-    "sprintf": "~0.1.3",
-    "tape": "~2.3.2",
     "minimist": "0.0.5",
-    "defined": "0.0.0"
+    "sprintf": "~0.1.3",
+    "tap-parser": "~0.4.0",
+    "through2": "~0.2.3"
   },
   "repository": {
     "type": "git",

--- a/readme.markdown
+++ b/readme.markdown
@@ -136,6 +136,8 @@ Once you've got a way to get TAP out of your tests, just pipe into `faucet`:
 ```
 usage:
   faucet [FILES]
+  faucet -n [FILES]
+  faucet -n[N] [FILES]
   command | faucet
 ```
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -141,7 +141,7 @@ usage:
 
 The command options and files arguments are both optional. Command options begin with `-` (dash). All other arguments are files.
 
-By default, `faucet` passes the files to the `tape` executable found in the [`tape` module](https://github.com/substack/tape). The environment variable `FAUCET_TAP_CMD` may override this with a a path to a different TAP-producing command. The provided options pass on to this command.
+By default, `faucet` passes the command options and files to the `tape` executable found in the [`tape` module](https://github.com/substack/tape). The environment variable `FAUCET_TAP_CMD` may override this with a a path to a different TAP-producing command.
 
 # license
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -135,11 +135,13 @@ Once you've got a way to get TAP out of your tests, just pipe into `faucet`:
 
 ```
 usage:
-  faucet [FILES]
-  faucet -n [FILES]
-  faucet -n[N] [FILES]
+  faucet [OPTIONS] [FILES]
   command | faucet
 ```
+
+The command options and files arguments are both optional. Command options begin with `-` (dash). All other arguments are files.
+
+By default, `faucet` passes the files to the `tape` executable found in the [`tape` module](https://github.com/substack/tape). The environment variable `FAUCET_TAP_CMD` may override this with a a path to a different TAP-producing command. The provided options pass on to this command.
 
 # license
 


### PR DESCRIPTION
This is a PR for proposal #19. It contains everything described in that request, plus one thing.

This version of `faucet` also supports the word "assertions" appearing in place of "tests" in the output summary. The word "tests" is still allowed. See [this `tape` issue](https://github.com/substack/tape/issues/306) for an explanation. I currently have [`tapeo`](https://www.npmjs.com/package/tapeo) patching `tape` to say "assertions" instead (but patching is not stable long-term).