### PR TITLE
fix(assert): Add default name for no test name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var duplexer = require('duplexer');
 var parser = require('tap-parser');
 var sprintf = require('sprintf');
 
+var DEFAULT_TEST_NAME = 'test';
+
 module.exports = function (opts) {
     if (!opts) opts = {};
     var tap = parser();
@@ -34,8 +36,10 @@ module.exports = function (opts) {
         var ok = res.ok ? 'ok' : 'not ok';
         var c = res.ok ? 32 : 31;
         if (!test) {
+            // Whenenver there is no test name, provide a default one.
+            var name = res.name || DEFAULT_TEST_NAME
             // mocha produces TAP results this way, whatever
-            var s = trim(res.name.trim());
+            var s = trim(name.trim());
             out.push(sprintf(
                 '\x1b[1m\x1b[' + c + 'm%s\x1b[0m\n',
                 trim((res.ok ? '✓' : '⨯') + ' ' +  s)


### PR DESCRIPTION
First of all I'm a big fan of **tape**! Thanks for that 😄  

I just discovered playing around with a custom TAP reporter for COBOL, (yep COBOL 😅) that whenever a TAP report has no name after the test or the name has no space `faucet` fails to parse the line.

For example given the following TAP as input:

```sh
TAP version 13
1..1
ok 1
```

or (without the space)

```sh 
TAP version 13
1..1
ok 1foo
```

```sh
/Users/alvaropinot/work/alvaropinot/faucet/index.js:38
            var s = trim(res.name.trim());
                                 ^

TypeError: Cannot read property 'trim' of undefined
    at Parser.<anonymous> (/Users/alvaropinot/work/alvaropinot/faucet/index.js:38:34)
    at emitOne (events.js:101:20)
    at Parser.emit (events.js:191:7)
    at Parser._online (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/tap-parser/index.js:131:14)
    at Parser._write (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/tap-parser/index.js:53:14)
    at doWrite (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/readable-stream/lib/_stream_writable.js:279:12)
    at writeOrBuffer (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/readable-stream/lib/_stream_writable.js:266:5)
    at Parser.Writable.write (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/readable-stream/lib/_stream_writable.js:211:11)
    at Stream.method [as write] (/Users/alvaropinot/work/alvaropinot/faucet/node_modules/duplexer/index.js:47:39)
    at Socket.ondata (_stream_readable.js:557:20)
```

This is a fix that prevents the problem but maybe the `tap-parser` should be fixed instead. I tried to follow the ES5 syntax and already existing style but please feel free to let me know any code standard/style that you want me to follow, if you want to merge this PR. 

I was willing to add both scenarios as tests but looks like there is none 😅, quite ironic being a test output lib 😜

Can you confirm if there is any other implications about changing https://github.com/substack/faucet/blob/0fabf821eb142dc75a318c5cd408d7653279bb00/index.js#L38 looks like name is used in some other lines 😄 

---

This are the proposed changes 👇 

**fix(assert): Add default name for no test name.**

 * Add `DEFAULT_TEST_NAME`.
 * Ensure `res.name` has a value or use `DEFAULT_TEST_NAME`.
